### PR TITLE
Refactor signal decorators to use pyqtSlot and update version to 2.0.1

### DIFF
--- a/pyqtspinner/configurator.py
+++ b/pyqtspinner/configurator.py
@@ -3,6 +3,7 @@ import sys
 from random import random
 
 from PySide6.QtCore import Qt, Slot
+from PySide6.QtGui import QClipboard
 from PySide6.QtWidgets import (
     QApplication,
     QColorDialog,
@@ -159,7 +160,7 @@ class SpinnerConfigurator(QWidget):
         self.spinner.start()
         self.show()
 
-    @Slot(name="randomize")
+    @pyqtSlot(name="randomize")
     def _randomize(self) -> None:
         self.sb_roundness.setValue(random() * 1000)
         self.sb_opacity.setValue(random() * 50)
@@ -170,13 +171,13 @@ class SpinnerConfigurator(QWidget):
         self.sb_inner_radius.setValue(math.floor(random() * 30))
         self.sb_rev_s.setValue(random())
 
-    @Slot(name="show_color_picker")
+    @pyqtSlot(name="show_color_picker")
     def show_color_picker(self) -> None:
         """Set the color for the spinner."""
         assert self.spinner
         self.spinner.color = QColorDialog.getColor()
 
-    @Slot(name="show_init_args")
+    @pyqtSlot(name="show_init_args")
     def show_init_args(self) -> None:
         """Display used arguments."""
         assert self.spinner
@@ -196,8 +197,8 @@ class SpinnerConfigurator(QWidget):
         msg_box.setText(text)
         msg_box.setWindowTitle("Text was copied to clipboard")
         clipboard = QApplication.clipboard()
-        clipboard.clear(mode=clipboard.Clipboard)
-        clipboard.setText(text, mode=clipboard.Clipboard)
+        clipboard.clear(mode=QClipboard.Mode.Clipboard)
+        clipboard.setText(text, mode=QClipboard.Mode.Clipboard)
         print(text)
         msg_box.exec_()
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = pyqtspinner
-version = 2.0.0
+version = 2.0.1
 description = Waiting spinner for PySide6
 author = Denis
 author_email = fbjorn@users.noreply.github.com


### PR DESCRIPTION
This pull request includes several changes to the `pyqtspinner` project, focusing on updating imports, correcting decorator usage, and modifying clipboard handling. Additionally, the project version has been incremented.

### Import Updates:
* Added `QClipboard` import to `pyqtspinner/configurator.py`.

### Decorator Corrections:
* Replaced `@Slot` with `@pyqtSlot` for the `_randomize`, `show_color_picker`, and `show_init_args` methods in `pyqtspinner/configurator.py`. [[1]](diffhunk://#diff-17bbca47fc6704b6a9d524a75e3e543d0ead262bc946b4b0e74a20979c78d431L162-R163) [[2]](diffhunk://#diff-17bbca47fc6704b6a9d524a75e3e543d0ead262bc946b4b0e74a20979c78d431L173-R180) [[3]](diffhunk://#diff-17bbca47fc6704b6a9d524a75e3e543d0ead262bc946b4b0e74a20979c78d431L199-R201)

### Clipboard Handling:
* Updated clipboard handling to use `QClipboard.Mode.Clipboard` instead of `clipboard.Clipboard` in `show_init_args` method.

### Version Increment:
* Incremented project version from `2.0.0` to `2.0.1` in `setup.cfg`.