### PR TITLE
Replace pyqtSlot with Slot decorator in SpinnerConfigurator methods

### DIFF
--- a/pyqtspinner/configurator.py
+++ b/pyqtspinner/configurator.py
@@ -160,7 +160,7 @@ class SpinnerConfigurator(QWidget):
         self.spinner.start()
         self.show()
 
-    @pyqtSlot(name="randomize")
+    @Slot(name="randomize")
     def _randomize(self) -> None:
         self.sb_roundness.setValue(random() * 1000)
         self.sb_opacity.setValue(random() * 50)
@@ -171,13 +171,13 @@ class SpinnerConfigurator(QWidget):
         self.sb_inner_radius.setValue(math.floor(random() * 30))
         self.sb_rev_s.setValue(random())
 
-    @pyqtSlot(name="show_color_picker")
+    @Slot(name="show_color_picker")
     def show_color_picker(self) -> None:
         """Set the color for the spinner."""
         assert self.spinner
         self.spinner.color = QColorDialog.getColor()
 
-    @pyqtSlot(name="show_init_args")
+    @Slot(name="show_init_args")
     def show_init_args(self) -> None:
         """Display used arguments."""
         assert self.spinner


### PR DESCRIPTION
This pull request includes changes to the `pyqtspinner/configurator.py` file to update the usage of decorators for slot methods. The changes involve replacing `@pyqtSlot` with `@Slot`.

Updates to slot decorators:

* [`pyqtspinner/configurator.py`](diffhunk://#diff-17bbca47fc6704b6a9d524a75e3e543d0ead262bc946b4b0e74a20979c78d431L163-R163): Replaced `@pyqtSlot` with `@Slot` in the `randomize` method.
* [`pyqtspinner/configurator.py`](diffhunk://#diff-17bbca47fc6704b6a9d524a75e3e543d0ead262bc946b4b0e74a20979c78d431L174-R180): Replaced `@pyqtSlot` with `@Slot` in the `show_color_picker` method.
* [`pyqtspinner/configurator.py`](diffhunk://#diff-17bbca47fc6704b6a9d524a75e3e543d0ead262bc946b4b0e74a20979c78d431L174-R180): Replaced `@pyqtSlot` with `@Slot` in the `show_init_args` method.