### PR TITLE
Update spinner opacity parameter and version to 2.0.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,5 @@ __pycache__
 .conda
 .test
 dist
+
+*.egg-info

--- a/pyqtspinner/spinner.py
+++ b/pyqtspinner/spinner.py
@@ -51,6 +51,7 @@ class WaitingSpinner(QWidget):
         radius: int = 10,
         speed: float = math.pi / 2,
         color: QColor = QColor(0, 0, 0),
+        opacity: float = math.pi,
     ) -> None:
         super().__init__(parent)
 
@@ -59,7 +60,7 @@ class WaitingSpinner(QWidget):
 
         self._color: QColor = color
         self._roundness: float = roundness
-        self._minimum_trail_opacity: float = math.pi
+        self._minimum_trail_opacity: float = opacity
         self._trail_fade_percentage: float = fade
         self._revolutions_per_second: float = speed
         self._number_of_lines: int = lines

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = pyqtspinner
-version = 2.0.1
+version = 2.0.2
 description = Waiting spinner for PySide6
 author = Denis
 author_email = fbjorn@users.noreply.github.com


### PR DESCRIPTION
This pull request includes changes to the `pyqtspinner` library to add an opacity parameter to the spinner and update the version number. The most important changes include modifying the `__init__` method to accept an opacity parameter and updating the version number in the `setup.cfg` file.

Enhancements to `pyqtspinner`:

* [`pyqtspinner/spinner.py`](diffhunk://#diff-2de7ffc33857b38bc46bc84aa5d7ee27970a115febd901e3c8f6feb12f638453R54): Added an `opacity` parameter to the `__init__` method to allow customization of the spinner's opacity.
* [`pyqtspinner/spinner.py`](diffhunk://#diff-2de7ffc33857b38bc46bc84aa5d7ee27970a115febd901e3c8f6feb12f638453L62-R63): Updated the `_minimum_trail_opacity` attribute to use the new `opacity` parameter instead of a hardcoded value.

Version update:

* [`setup.cfg`](diffhunk://#diff-fa602a8a75dc9dcc92261bac5f533c2a85e34fcceaff63b3a3a81d9acde2fc52L3-R3): Updated the version number from `2.0.1` to `2.0.2` to reflect the new changes.